### PR TITLE
Use mvn -pl :artifactId in org.walkmod.maven.providers.MavenProject#build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/target
+target
 *.project
 *.classpath
 *.class
+.idea
+*.iml

--- a/src/test/java/org/walkmod/maven/providers/ClassLoaderConfigurationProviderTest.java
+++ b/src/test/java/org/walkmod/maven/providers/ClassLoaderConfigurationProviderTest.java
@@ -89,4 +89,14 @@ public class ClassLoaderConfigurationProviderTest {
 		}
 	}
 
+	@Test
+	public void testClassLoaderFromProjectWithParentProjectInSubfolder() throws Exception {
+		File pom = new File("src/test/sample3/child/pom.xml");
+		Assert.assertTrue(pom.exists());
+		MavenProject reader = new MavenProject(pom);
+		reader.build();
+		List<MavenResolvedArtifact> dependencies = reader.getArtifacts();
+		Assert.assertTrue(dependencies.isEmpty());
+	}
+
 }

--- a/src/test/sample3/child/pom.xml
+++ b/src/test/sample3/child/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>myorg</groupId>
+		<artifactId>myproject-parent</artifactId>
+		<version>1.0.0.Final-SNAPSHOT</version>
+		<relativePath>../parent/pom.xml</relativePath>
+	</parent>
+
+	<artifactId>sample3-child</artifactId>
+
+	<version>1.0-SNAPSHOT</version>
+
+</project>

--- a/src/test/sample3/parent/pom.xml
+++ b/src/test/sample3/parent/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Parent -->
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>14</version>
+        <relativePath />
+    </parent>
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Artifact Configuration -->
+    <groupId>myorg</groupId>
+    <artifactId>myproject-parent</artifactId>
+    <version>1.0.0.Final-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>../child</module>
+    </modules>
+
+</project>


### PR DESCRIPTION
Running maven fails when parent folder does not contain the child folder, as shown in sample3
